### PR TITLE
Calculates path to mapping file on non-dexguarded builds

### DIFF
--- a/src/main/kotlin/com/guardsquare/appsweep/gradle/AppSweepPlugin.kt
+++ b/src/main/kotlin/com/guardsquare/appsweep/gradle/AppSweepPlugin.kt
@@ -64,8 +64,12 @@ class AppSweepPlugin : Plugin<Project> {
                 calculateDependsOn = { variant -> variant.assembleProvider },
                 calculateTags = { variant, tags -> setTags(variant, tags) },
                 calculateAppToUpload = { file -> file },
-                calculateMappingFile = { null }
+                calculateMappingFile = { variant ->
+                    Paths.get(project.buildDir.absolutePath, "outputs", "mapping", variant.name, "mapping.txt")
+                    .toAbsolutePath()
+                    .toString() }
             )
+
             if (project.extensions.findByName("dexguard") != null) {
                 // depend on dexguardApk${variant.Name}, upload protected apk
                 registerTasksForVariants(project,
@@ -76,13 +80,15 @@ class AppSweepPlugin : Plugin<Project> {
                         calculateDependsOn = { variant -> "dexguardApk${variant.name.capitalize()}" },
                         calculateTags = { variant, tags -> setTags(variant, tags, "Protected") },
                         calculateAppToUpload = { file -> File(file.parentFile, "${file.nameWithoutExtension}-protected.${file.extension}") },
-                        calculateMappingFile = { variant -> Paths.get(project.buildDir.absolutePath, "outputs", "dexguard", "mapping", "apk", variant.name, "mapping.txt")
+                        calculateMappingFile = { variant ->
+                            Paths.get(project.buildDir.absolutePath, "outputs", "dexguard", "mapping", "apk", variant.name, "mapping.txt")
                                 .toAbsolutePath()
                                 .toString() }
                 )
             }
         }
     }
+
 
     /**
      * Register Tasks for all variants of this project.


### PR DESCRIPTION
Hi 👋🏼

## What

Rising this PR as per suggestion given in this [thread from Guardsquare community](https://community.guardsquare.com/t/appsweep-not-collecting-mapping-txt-files-for-non-dexguarded-builds/945/2)

## How

This PR enables the upload of `mapping.txt` file for non Dexguarded builds by calculating the conventional path 

```
<buildDir>/outputs/mapping/<variant>/mapping.txt
```

when registering the `appsweep` tasks for project's variants.

Tested locally and it seems the upload is working fine. 
